### PR TITLE
A few bug fixes

### DIFF
--- a/barcode_to_sun_addresses.pl
+++ b/barcode_to_sun_addresses.pl
@@ -14,6 +14,7 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use warnings qw(all);
+use strict;
 
 use Getopt::Long;
 use Pod::Usage;
@@ -105,15 +106,14 @@ $hostid = $machine_type + $serial;
 
 # Be able to print the MAC address:
 # First, add the standard old Sun OUI:
-$mac_address[0] = 8;
-$mac_address[1] = 0;
-$mac_address[2] = 20;
+
+my @mac_address = ( 8, 0, 20 );
 
 # Next, parse out the host portion; we use substr() in reverse
 # as negative serials cause a problem if we don't
-$mac_address[3] = substr(sprintf("%06X", $mac), -6, 2);
-$mac_address[4] = substr(sprintf("%06X", $mac), -4, 2);
-$mac_address[5] = substr(sprintf("%06X", $mac), -2);
+push @mac_address, (substr(sprintf("%06X", $mac), -6, 2));
+push @mac_address, (substr(sprintf("%06X", $mac), -4, 2));
+push @mac_address, (substr(sprintf("%06X", $mac), -2));
 my $mac_string = join(":",@mac_address);
 
 # Print our variables

--- a/barcode_to_sun_addresses.pl
+++ b/barcode_to_sun_addresses.pl
@@ -69,13 +69,21 @@ e.g. if you were going to run this for a SPARCstation 1 with a barcode of 'JET2'
 
 =cut
 
+# declare variables for options
+my $help = 0;
+my $machine_type;
+my $barcode;
+
 # Deal with the command line arguments
 GetOptions(
-    'help'          => \my $help,
-    'machine_type=s'    => \my $machine_type,
-    'barcode=s'    => \my $barcode
-) or pod2usage(q(-verbose) => 1);
-pod2usage(q(-verbose) => 2) if $help;
+    'help|h!'         => \$help,
+    'machine_type|m=s' => \$machine_type,
+    'barcode|b=s'      => \$barcode
+) or pod2usage(-verbose => 1, -exitval => 1, -output => \*STDERR);
+
+pod2usage(-verbose => 2) if $help;
+
+pod2usage(-verbose => 1, -exitval => 1, -output => \*STDERR) unless ($machine_type && $barcode);
 
 # Some more variables we should declare
 my $hostid;

--- a/barcode_to_sun_addresses.pl
+++ b/barcode_to_sun_addresses.pl
@@ -105,7 +105,7 @@ $hostid = $machine_type + $serial;
 
 # Be able to print the MAC address:
 # First, add the standard old Sun OUI:
-$mac_address[0] = 80;
+$mac_address[0] = 8;
 $mac_address[1] = 0;
 $mac_address[2] = 20;
 


### PR DESCRIPTION
closes #1 and does a few more improvements.

I turned on `use strict;` and then cleaned up the array definition for `@mac_address` as `strict` complains about undeclared arrays.  I also updated the option handling a bit, namely making it so that it fails out and prints the synopsis if the required arguments aren't provided